### PR TITLE
fix(gestor): Correção do Erro 400 nos formulários e ajuste do modelo Gemini

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Copilot Instructions - biblioWebapp
+
+## Contexto do projeto
+- Frontend SPA com JavaScript vanilla, Web Components e Vite.
+- Domínios principais em `src/domains/` (controller/view/service).
+- Componentes visuais em `src/components/`.
+
+## Princípios de implementação
+- Priorizar legibilidade e consistência sobre abstrações prematuras.
+- Evitar criar aliases/proxies de compatibilidade quando houver padrão final definido.
+- Preservar APIs públicas existentes sempre que possível.
+- Alterações devem ser pequenas, incrementais e testáveis.
+
+## Arquitetura e organização
+- Regras de negócio e chamadas HTTP em `service`.
+- Orquestração de fluxo em `controller`.
+- Renderização e manipulação de DOM em `view`/Web Components.
+- Evitar misturar lógica de negócio com renderização no mesmo bloco.
+
+## Integrações externas
+- Nunca consumir APIs externas sensíveis diretamente do browser quando houver segredo.
+- Preferir backend como fachada para integração externa.
+- Tratar timeout, falha de rede e respostas vazias com UX clara.
+- Aplicar debounce em buscas automáticas e cache local quando fizer sentido.
+
+## Formulários e UX
+- Não sobrescrever campos já preenchidos pelo usuário sem confirmação explícita.
+- Exibir estados de carregamento e erro no próprio formulário (evitar somente `alert`).
+- Manter validações de entrada no frontend e no backend.
+- Garantir textos de interface em pt-BR com acentuação correta.
+
+## Estilo (CSS)
+- Utilizar sempre cores via variáveis CSS (`var(--...)`), sem hex/rgb literais em componentes.
+- Quando uma cor nova for necessária, primeiro criar token no arquivo global (`src/css/main.css`) e reutilizar.
+- Preferir nomes semânticos para tokens (ex.: `--color-feedback-error`) em vez de nomes por tom.
+
+## Variáveis de ambiente
+- Usar apenas `import.meta.env.VITE_*` no frontend.
+- Nunca incluir secrets/chaves privadas em variáveis `VITE_*`.
+- Documentar todas as variáveis novas no `.env.example`.
+
+## Qualidade
+- Ao adicionar feature, incluir ao menos:
+  - tratamento de estado de loading e erro
+  - validação de entrada
+  - documentação de comportamento no README quando necessário
+- Executar build (`npm run build`) após mudanças relevantes.
+
+## Definition of Done (DoD)
+- Feature implementada sem quebrar fluxos existentes.
+- Mensagens e labels revisadas em pt-BR.
+- Variáveis de ambiente adicionadas e documentadas.
+- Erros tratados para falhas de rede/API.
+- Build do frontend concluindo sem erro.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,24 @@ O sistema permite:
 - **Gerenciamento de Livros:**
   - Listar todos os livros cadastrados.
   - Adicionar novos livros com informações como título, autor, editora, data de publicação, ISBN, número de páginas, URL da capa, idioma e gênero.
+  - Preencher automaticamente campos do formulário a partir do ISBN (quando os demais campos ainda estão vazios).
   - Editar informações de livros existentes.
   - Excluir livros.
+
+## Cadastro facilitado por ISBN
+
+No formulário de livro, ao informar ISBN válido:
+
+- A aplicação consulta o backend (`/gestor/livros/isbn-lookup/`).
+- O backend busca metadados na Open Library e traduz textos para pt-BR.
+- O formulário preenche somente campos vazios para evitar sobreposição de dados já digitados.
+
+## Variáveis de ambiente
+
+As variáveis abaixo estão em `.env.example`:
+
+- `VITE_API_URL`: URL base da API backend.
+- `VITE_ISBN_LOOKUP_ENABLED`: habilita/desabilita o preenchimento automático por ISBN (`true`/`false`).
 
 ## Estrutura do Projeto
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,5 +1,9 @@
 // src/api.js
-const API_URL = (import.meta.env.VITE_API_URL ?? 'https://biblio-webapi.onrender.com/gestor')
+const defaultApiUrl = import.meta.env.DEV
+  ? 'http://127.0.0.1:8000/gestor'
+  : 'https://biblio-webapi.onrender.com/gestor';
+
+const API_URL = (import.meta.env.VITE_API_URL ?? defaultApiUrl)
   .replace(/\/$/, ''); // sem barra no final
 
 export async function getLivros() {

--- a/src/components/livro/livro-form.css
+++ b/src/components/livro/livro-form.css
@@ -35,6 +35,47 @@
     gap: 1rem;
 }
 
+.isbn-input-wrapper {
+    position: relative;
+}
+
+.isbn-input-wrapper input {
+    padding-right: 2.6rem;
+}
+
+.isbn-lookup-trigger {
+    position: absolute;
+    top: 0;
+    right: 0.55rem;
+    transform: translateY(50%);
+    width: 1.7rem;
+    height: 1.7rem;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--color-feedback-neutral);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.isbn-lookup-trigger:hover,
+.isbn-lookup-trigger:focus-visible {
+    color: var(--color-feedback-loading);
+    background: var(--color-surface-muted);
+}
+
+.isbn-input-wrapper[data-loading="true"] .isbn-lookup-trigger {
+    color: var(--color-feedback-loading);
+    cursor: progress;
+}
+
+.isbn-input-wrapper[data-loading="true"] .isbn-lookup-trigger i {
+    animation: isbn-inline-spin 0.9s linear infinite;
+}
+
 .isbn-feedback {
     display: block;
     margin-top: 0.35rem;
@@ -98,6 +139,12 @@
 }
 
 @keyframes isbn-global-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes isbn-inline-spin {
     to {
         transform: rotate(360deg);
     }

--- a/src/components/livro/livro-form.css
+++ b/src/components/livro/livro-form.css
@@ -35,6 +35,74 @@
     gap: 1rem;
 }
 
+.isbn-feedback {
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 0.85rem;
+    color: var(--color-feedback-neutral);
+    min-height: 1.1rem;
+}
+
+.isbn-feedback.is-success {
+    color: var(--color-feedback-success);
+}
+
+.isbn-feedback.is-error {
+    color: var(--color-feedback-error);
+}
+
+.isbn-feedback.is-loading {
+    color: var(--color-feedback-loading);
+}
+
+.isbn-global-loading {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: color-mix(in srgb, var(--color-background) 84%, transparent);
+    z-index: 999;
+}
+
+.isbn-global-loading[hidden] {
+    display: none;
+}
+
+#livro-form {
+    position: relative;
+}
+
+.isbn-global-loading-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.65rem 0.95rem;
+    border-radius: 8px;
+    border: 1px solid var(--color-border-subtle);
+    background: var(--color-surface-muted);
+    color: var(--color-feedback-loading);
+    font-weight: 600;
+}
+
+.isbn-global-loading-spinner {
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 999px;
+    border: 2px solid var(--color-border-subtle);
+    border-top-color: var(--color-feedback-loading);
+    animation: isbn-global-spin 0.9s linear infinite;
+}
+
+@keyframes isbn-global-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 @media (max-width: 768px) {
     .livro-unidade-header {
         grid-template-columns: 1fr;

--- a/src/components/livro/livro-form.js
+++ b/src/components/livro/livro-form.js
@@ -43,7 +43,17 @@ class LivroForm extends HTMLElement {
                 </div>
                 <div>
                     <label for="isbn">ISBN:</label>
-                    <input type="text" id="isbn" name="isbn">
+                    <div class="isbn-input-wrapper" data-loading="false">
+                      <input type="text" id="isbn" name="isbn">
+                      <button
+                        type="button"
+                        id="isbn-lookup-trigger"
+                        class="isbn-lookup-trigger"
+                        aria-label="Buscar dados do ISBN ao sair do campo"
+                        title="Clique para buscar (ou saia do campo ISBN)">
+                        <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                      </button>
+                    </div>
                   <small id="isbn-feedback" class="isbn-feedback" aria-live="polite"></small>
                 </div>
                 <div>
@@ -136,6 +146,8 @@ class LivroForm extends HTMLElement {
       const unidadesListDiv = this.querySelector("#livro-unidades-list");
       const form = this.querySelector("#livro-form");
       const isbnInput = this.querySelector("#isbn");
+      const isbnLookupTrigger = this.querySelector("#isbn-lookup-trigger");
+      const isbnInputWrapper = this.querySelector(".isbn-input-wrapper");
       const isbnFeedback = this.querySelector("#isbn-feedback");
       const formFeedback = this.querySelector("#livro-form-feedback");
       const isbnGlobalLoading = this.querySelector("#isbn-global-loading");
@@ -173,6 +185,14 @@ class LivroForm extends HTMLElement {
             isbnGlobalLoadingText.textContent = message;
           }
           isbnGlobalLoading.hidden = !isLoading;
+        }
+
+        if (isbnInputWrapper) {
+          isbnInputWrapper.dataset.loading = isLoading ? "true" : "false";
+        }
+
+        if (isbnLookupTrigger) {
+          isbnLookupTrigger.disabled = isLoading;
         }
       };
 
@@ -219,7 +239,10 @@ class LivroForm extends HTMLElement {
         return changedFields;
       };
 
-      const buscarPorIsbn = async () => {
+      let lookupInFlight = false;
+      let lastLookupKey = "";
+
+      const buscarPorIsbn = async (source = "blur") => {
         const isbnLookupEnabled =
           typeof import.meta !== "undefined" &&
           import.meta &&
@@ -233,9 +256,18 @@ class LivroForm extends HTMLElement {
 
         const rawIsbn = String(isbnInput?.value || "").trim();
         const isbn = rawIsbn.replace(/[^0-9Xx]/g, "");
+        const lookupKey = isbn.toUpperCase();
 
         if (isbn.length < 10) {
           setIsbnFeedback("");
+          return;
+        }
+
+        if (lookupInFlight) {
+          return;
+        }
+
+        if (source !== "input-hint" && lastLookupKey === lookupKey) {
           return;
         }
 
@@ -258,6 +290,7 @@ class LivroForm extends HTMLElement {
         }
 
         try {
+          lookupInFlight = true;
           setLookupLoading(true, "Buscando dados do ISBN...");
           setIsbnFeedback("Consultando ISBN e traduzindo dados...", "loading");
           const result = await lookupFn.call(window.gestorController.service, rawIsbn);
@@ -268,6 +301,7 @@ class LivroForm extends HTMLElement {
           }
 
           const changed = preencherCamposComLookup(data);
+          lastLookupKey = lookupKey;
           if (changed > 0) {
             setIsbnFeedback("Dados preenchidos automaticamente com sucesso.", "success");
           } else {
@@ -278,6 +312,7 @@ class LivroForm extends HTMLElement {
             (error && error.message) || "Não foi possível consultar o ISBN agora.";
           setIsbnFeedback(message, "error");
         } finally {
+          lookupInFlight = false;
           setLookupLoading(false);
         }
       };
@@ -285,10 +320,43 @@ class LivroForm extends HTMLElement {
       let isbnDebounceTimer = null;
       if (isbnInput) {
         isbnInput.addEventListener("input", () => {
+          lastLookupKey = "";
           if (isbnDebounceTimer) clearTimeout(isbnDebounceTimer);
+
+          const rawIsbn = String(isbnInput.value || "").trim();
+          const isbn = rawIsbn.replace(/[^0-9Xx]/g, "");
+
+          if (!rawIsbn) {
+            setIsbnFeedback("");
+            return;
+          }
+
+          if (isbn.length < 10) {
+            setIsbnFeedback("Complete o ISBN para habilitar a busca automática ao sair do campo.", "neutral");
+            return;
+          }
+
           isbnDebounceTimer = setTimeout(() => {
-            buscarPorIsbn();
+            setIsbnFeedback(
+              "ISBN pronto. Ao sair do campo, vamos buscar os dados automaticamente.",
+              "neutral"
+            );
           }, 700);
+        });
+
+        isbnInput.addEventListener("blur", () => {
+          if (isbnDebounceTimer) clearTimeout(isbnDebounceTimer);
+          buscarPorIsbn("blur");
+        });
+      }
+
+      if (isbnLookupTrigger && isbnInput) {
+        isbnLookupTrigger.addEventListener("click", () => {
+          if (document.activeElement === isbnInput) {
+            isbnInput.blur();
+            return;
+          }
+          buscarPorIsbn("icon");
         });
       }
 

--- a/src/components/livro/livro-form.js
+++ b/src/components/livro/livro-form.js
@@ -42,6 +42,11 @@ class LivroForm extends HTMLElement {
                     }</h2>
                 </div>
                 <div>
+                    <label for="isbn">ISBN:</label>
+                    <input type="text" id="isbn" name="isbn">
+                  <small id="isbn-feedback" class="isbn-feedback" aria-live="polite"></small>
+                </div>
+                <div>
                     <label for="titulo">Título:</label>
                     <input type="text" id="titulo" name="titulo" required>
                 </div>
@@ -56,10 +61,6 @@ class LivroForm extends HTMLElement {
                 <div>
                     <label for="data_publicacao">Data de Publicação:</label>
                     <input type="date" id="data_publicacao" name="data_publicacao">
-                </div>
-                <div>
-                    <label for="isbn">ISBN:</label>
-                    <input type="text" id="isbn" name="isbn">
                 </div>
                 <div>
                     <label for="paginas">Páginas:</label>
@@ -103,9 +104,16 @@ class LivroForm extends HTMLElement {
                      <button type="button" id="add-unidade-livro" class="outline">Adicionar Unidade</button>
                 </div>
                 <div id="livro-unidades-list" style="margin:8px 0 16px 0;"></div>
+                <small id="livro-form-feedback" class="app-inline-feedback" aria-live="polite"></small>
                 <div class="livro-form-footer">
                     <button type="button" id="cancelar-btn" class="outline">Cancelar</button>
                     <button type="submit">Salvar Livro</button>
+                </div>
+                <div id="isbn-global-loading" class="isbn-global-loading" hidden>
+                  <div class="isbn-global-loading-card">
+                    <span class="isbn-global-loading-spinner" aria-hidden="true"></span>
+                    <span id="isbn-global-loading-text">Buscando dados do ISBN...</span>
+                  </div>
                 </div>
             </form>
         `;
@@ -127,6 +135,163 @@ class LivroForm extends HTMLElement {
       const addUnidadeBtn = this.querySelector("#add-unidade-livro");
       const unidadesListDiv = this.querySelector("#livro-unidades-list");
       const form = this.querySelector("#livro-form");
+      const isbnInput = this.querySelector("#isbn");
+      const isbnFeedback = this.querySelector("#isbn-feedback");
+      const formFeedback = this.querySelector("#livro-form-feedback");
+      const isbnGlobalLoading = this.querySelector("#isbn-global-loading");
+      const isbnGlobalLoadingText = this.querySelector("#isbn-global-loading-text");
+
+      const setIsbnFeedback = (message, tone = "neutral") => {
+        if (!isbnFeedback) return;
+        isbnFeedback.textContent = message || "";
+        isbnFeedback.classList.remove("is-success", "is-error", "is-loading");
+        if (tone === "success") isbnFeedback.classList.add("is-success");
+        if (tone === "error") isbnFeedback.classList.add("is-error");
+        if (tone === "loading") isbnFeedback.classList.add("is-loading");
+      };
+
+      const setLookupLoading = (
+        isLoading,
+        message = "Buscando dados do ISBN..."
+      ) => {
+        const controls = form.querySelectorAll("input, select, button, textarea");
+        controls.forEach((control) => {
+          if (isLoading) {
+            control.dataset.isbnPrevDisabled = control.disabled ? "1" : "0";
+            control.disabled = true;
+            return;
+          }
+
+          if (control.dataset.isbnPrevDisabled === "0") {
+            control.disabled = false;
+          }
+          delete control.dataset.isbnPrevDisabled;
+        });
+
+        if (isbnGlobalLoading) {
+          if (isbnGlobalLoadingText) {
+            isbnGlobalLoadingText.textContent = message;
+          }
+          isbnGlobalLoading.hidden = !isLoading;
+        }
+      };
+
+      const hasAnyMainFieldValue = () => {
+        const fields = [
+          "titulo",
+          "autor",
+          "editora",
+          "data_publicacao",
+          "paginas",
+          "capa",
+          "idioma",
+        ];
+        return fields.some((fieldName) => {
+          const element = form[fieldName];
+          if (!element) return false;
+          return String(element.value || "").trim() !== "";
+        });
+      };
+
+      const preencherCamposComLookup = (lookupData) => {
+        const fieldMap = {
+          titulo: "titulo",
+          autor: "autor",
+          editora: "editora",
+          data_publicacao: "data_publicacao",
+          paginas: "paginas",
+          capa: "capa",
+          idioma: "idioma",
+        };
+
+        let changedFields = 0;
+        Object.entries(fieldMap).forEach(([fieldName, lookupKey]) => {
+          const input = form[fieldName];
+          if (!input) return;
+          const currentValue = String(input.value || "").trim();
+          const incomingValue = String(lookupData[lookupKey] || "").trim();
+          if (!currentValue && incomingValue) {
+            input.value = incomingValue;
+            changedFields += 1;
+          }
+        });
+
+        return changedFields;
+      };
+
+      const buscarPorIsbn = async () => {
+        const isbnLookupEnabled =
+          typeof import.meta !== "undefined" &&
+          import.meta &&
+          import.meta.env &&
+          import.meta.env.VITE_ISBN_LOOKUP_ENABLED !== "false";
+
+        if (!isbnLookupEnabled) {
+          setIsbnFeedback("");
+          return;
+        }
+
+        const rawIsbn = String(isbnInput?.value || "").trim();
+        const isbn = rawIsbn.replace(/[^0-9Xx]/g, "");
+
+        if (isbn.length < 10) {
+          setIsbnFeedback("");
+          return;
+        }
+
+        if (hasAnyMainFieldValue()) {
+          setIsbnFeedback(
+            "Busca automática ignorada para não sobrescrever dados já preenchidos.",
+            "neutral"
+          );
+          return;
+        }
+
+        const lookupFn =
+          window.gestorController &&
+          window.gestorController.service &&
+          window.gestorController.service.lookupLivroPorIsbn;
+
+        if (typeof lookupFn !== "function") {
+          setIsbnFeedback("Serviço de ISBN indisponível no momento.", "error");
+          return;
+        }
+
+        try {
+          setLookupLoading(true, "Buscando dados do ISBN...");
+          setIsbnFeedback("Consultando ISBN e traduzindo dados...", "loading");
+          const result = await lookupFn.call(window.gestorController.service, rawIsbn);
+          const data = result && result.data ? result.data : null;
+          if (!data) {
+            setIsbnFeedback("Nenhum dado encontrado para este ISBN.", "error");
+            return;
+          }
+
+          const changed = preencherCamposComLookup(data);
+          if (changed > 0) {
+            setIsbnFeedback("Dados preenchidos automaticamente com sucesso.", "success");
+          } else {
+            setIsbnFeedback("ISBN encontrado, mas não houve campos vazios para preencher.", "neutral");
+          }
+        } catch (error) {
+          const message =
+            (error && error.message) || "Não foi possível consultar o ISBN agora.";
+          setIsbnFeedback(message, "error");
+        } finally {
+          setLookupLoading(false);
+        }
+      };
+
+      let isbnDebounceTimer = null;
+      if (isbnInput) {
+        isbnInput.addEventListener("input", () => {
+          if (isbnDebounceTimer) clearTimeout(isbnDebounceTimer);
+          isbnDebounceTimer = setTimeout(() => {
+            buscarPorIsbn();
+          }, 700);
+        });
+      }
+
       // Se for edição, popular a lista de unidades já escolhidas
       if (
         isEdit &&
@@ -183,6 +348,16 @@ class LivroForm extends HTMLElement {
         renderUnidadesList();
       };
       form.addEventListener("submit", (event) => {
+        if (isbnGlobalLoading && !isbnGlobalLoading.hidden) {
+          event.preventDefault();
+          if (formFeedback) {
+            formFeedback.textContent = "Aguarde a busca do ISBN finalizar para salvar.";
+            formFeedback.classList.remove("is-success", "is-loading");
+            formFeedback.classList.add("is-error");
+          }
+          return false;
+        }
+
         // Validação extra: data e ISBN
         const dataPub = form.data_publicacao?.value;
         const isbn = form.isbn?.value;
@@ -195,9 +370,18 @@ class LivroForm extends HTMLElement {
           }
         }
         if ((dataInvalida || !dataPub) && (!isbn || isbn.trim() === "")) {
-          alert("Informe uma data de publicação válida ou um ISBN.");
+          if (formFeedback) {
+            formFeedback.textContent = "Informe uma data de publicação válida ou um ISBN.";
+            formFeedback.classList.remove("is-success", "is-loading");
+            formFeedback.classList.add("is-error");
+          }
           event.preventDefault();
           return false;
+        }
+
+        if (formFeedback) {
+          formFeedback.textContent = "";
+          formFeedback.classList.remove("is-error", "is-success", "is-loading");
         }
         // Adiciona as unidades selecionadas ao form para o controller
         if (form._livroUnidades && form._livroUnidades.length > 0) {

--- a/src/components/livro/livro-list.js
+++ b/src/components/livro/livro-list.js
@@ -284,10 +284,19 @@ class LivroList extends HTMLElement {
       };
     });
     this.querySelectorAll(".delete-livro-icon").forEach((btn) => {
-      btn.onclick = (e) => {
+      btn.onclick = async (e) => {
         e.preventDefault();
         if (window.confirm("Tem certeza que deseja excluir este livro?")) {
-          if (this._onDelete) this._onDelete(parseInt(btn.dataset.id));
+          if (!this._onDelete) return;
+          const originalHtml = btn.innerHTML;
+          btn.disabled = true;
+          btn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
+          try {
+            await Promise.resolve(this._onDelete(parseInt(btn.dataset.id)));
+          } finally {
+            btn.disabled = false;
+            btn.innerHTML = originalHtml;
+          }
         }
       };
     });

--- a/src/components/unidade/unidade-form.js
+++ b/src/components/unidade/unidade-form.js
@@ -32,6 +32,7 @@ class UnidadeForm extends HTMLElement {
           <label for="site">Site:</label>
           <input type="url" id="site" name="site" />
         </div>
+        <small id="unidade-form-feedback" class="app-inline-feedback" aria-live="polite"></small>
         <div class="unidade-form-footer">
           <button type="button" id="cancelar-unidade-btn" class="outline">Cancelar</button>
           <button type="submit">Salvar Unidade</button>

--- a/src/components/unidade/unidade-list.js
+++ b/src/components/unidade/unidade-list.js
@@ -96,10 +96,19 @@ class UnidadeList extends HTMLElement {
       };
     });
     this.querySelectorAll(".delete-unidade-icon").forEach((btn) => {
-      btn.onclick = (e) => {
+      btn.onclick = async (e) => {
         e.preventDefault();
         if (window.confirm("Tem certeza que deseja excluir esta unidade?")) {
-          if (this._onDelete) this._onDelete(parseInt(btn.dataset.id));
+          if (!this._onDelete) return;
+          const originalHtml = btn.innerHTML;
+          btn.disabled = true;
+          btn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i>';
+          try {
+            await Promise.resolve(this._onDelete(parseInt(btn.dataset.id)));
+          } finally {
+            btn.disabled = false;
+            btn.innerHTML = originalHtml;
+          }
         }
       };
     });

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -13,6 +13,117 @@
     --color-accent1: #FBCDCD;
     --color-accent2: #F5CA6E;
     --color-accent3: #F3A04E;
+
+    --color-feedback-neutral: #475569;
+    --color-feedback-success: #0F766E;
+    --color-feedback-error: #B91C1C;
+    --color-feedback-loading: #1D4ED8;
+
+    --color-surface-muted: #F1F5F9;
+    --color-border-subtle: #CBD5E1;
+}
+
+.app-loading-panel {
+    padding: 1rem;
+    border: 1px solid var(--color-border-subtle);
+    background: var(--color-surface-muted);
+    border-radius: 8px;
+    color: var(--color-feedback-loading);
+}
+
+.app-global-loading {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: color-mix(in srgb, var(--color-background) 84%, transparent);
+    z-index: 1200;
+}
+
+.app-global-loading[hidden] {
+    display: none;
+}
+
+.app-global-loading-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: 10px;
+    background: var(--color-surface-muted);
+    color: var(--color-feedback-loading);
+    font-weight: 600;
+}
+
+.app-global-loading-spinner {
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 999px;
+    border: 2px solid var(--color-border-subtle);
+    border-top-color: var(--color-feedback-loading);
+    animation: app-global-spin 0.9s linear infinite;
+}
+
+@keyframes app-global-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.app-inline-feedback {
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 0.85rem;
+    min-height: 1.1rem;
+    color: var(--color-feedback-neutral);
+}
+
+.app-inline-feedback.is-error {
+    color: var(--color-feedback-error);
+}
+
+.app-inline-feedback.is-success {
+    color: var(--color-feedback-success);
+}
+
+.app-inline-feedback.is-loading {
+    color: var(--color-feedback-loading);
+}
+
+.app-toast {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 1000;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    color: var(--color-background);
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.18);
+}
+
+.app-toast.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.app-toast-info {
+    background: var(--color-feedback-loading);
+}
+
+.app-toast-success {
+    background: var(--color-feedback-success);
+}
+
+.app-toast-error {
+    background: var(--color-feedback-error);
 }
 
 body>main:not(.main-login) {
@@ -55,7 +166,7 @@ body>main:not(.main-login) {
     max-width: 420px;
     margin: auto;
     text-align: center;
-    background: #fffdf9;
+    background: var(--color-background);
     padding: 1rem;
 }
 

--- a/src/domains/auth/auth-view.js
+++ b/src/domains/auth/auth-view.js
@@ -14,6 +14,7 @@ export class AuthView {
             <label for="password">Senha:</label>
             <input type="password" id="password" name="password" placeholder="Digite qualquer senha" />
           </div>
+          <small id="login-feedback" class="app-inline-feedback" aria-live="polite"></small>
           <button type="submit">Entrar</button>
         </form>
         <div style="text-align:center;margin-top:1.5rem;">
@@ -38,5 +39,35 @@ export class AuthView {
         window.navigate && window.navigate("/faq");
       });
     }
+  }
+
+  setLoading(isLoading) {
+    const form = document.getElementById("login-form");
+    if (!form) return;
+    const button = form.querySelector('button[type="submit"]');
+    const feedback = document.getElementById("login-feedback");
+    if (!button) return;
+
+    if (isLoading) {
+      button.disabled = true;
+      button.textContent = "Entrando...";
+      if (feedback) {
+        feedback.textContent = "Validando credenciais...";
+        feedback.classList.remove("is-error", "is-success");
+        feedback.classList.add("is-loading");
+      }
+      return;
+    }
+
+    button.disabled = false;
+    button.textContent = "Entrar";
+  }
+
+  showError(message) {
+    const feedback = document.getElementById("login-feedback");
+    if (!feedback) return;
+    feedback.textContent = message || "Não foi possível entrar.";
+    feedback.classList.remove("is-loading", "is-success");
+    feedback.classList.add("is-error");
   }
 }

--- a/src/domains/base-service.js
+++ b/src/domains/base-service.js
@@ -18,12 +18,17 @@ export class BaseService {
       viteEnv = {};
     }
 
+    const isDev = Boolean(viteEnv.DEV);
+    const defaultBaseUrl = isDev
+      ? "http://127.0.0.1:8000"
+      : "https://biblio-webapi.onrender.com";
+
     const fromEnv =
       baseUrl ||
       viteEnv.VITE_API_URL ||
       viteEnv.VITE_API_BASE_URL ||
       (typeof window !== "undefined" && window.API_URL) ||
-      "https://biblio-webapi.onrender.com";
+      defaultBaseUrl;
 
     // Normaliza baseUrl sem barra final
     this.baseUrl = String(fromEnv).trim().replace(/\/+$/, "");

--- a/src/domains/base-service.js
+++ b/src/domains/base-service.js
@@ -107,8 +107,20 @@ export class BaseService {
           if (vercelHint === "NOT_FOUND") {
             throw new Error(`404 (Vercel NOT_FOUND) na URL: ${url}`);
           }
-          const detail = raw || res.statusText || "Erro HTTP";
-          throw new Error(`Erro ${res.status} em ${url} — ${detail}`);
+          let detail = raw || res.statusText || "Erro HTTP";
+
+          if (raw && contentType.includes("application/json")) {
+            try {
+              const parsed = JSON.parse(raw);
+              if (typeof parsed?.detail === "string" && parsed.detail.trim()) {
+                detail = parsed.detail.trim();
+              }
+            } catch {
+              // Mantém o texto bruto quando a resposta não puder ser parseada.
+            }
+          }
+
+          throw new Error(detail);
         }
 
         if (contentType.includes("application/json")) {

--- a/src/domains/gestor/gestor-controller.js
+++ b/src/domains/gestor/gestor-controller.js
@@ -5,6 +5,7 @@
 import { GestorService } from "./gestor-service.js";
 import { GestorView } from "./gestor-view.js";
 import { GestorInitService } from "./gestor-init-service.js";
+import { extractFriendlyError, showToast } from "../../utils/feedback.js";
 
 // Função de navegação SPA
 const navigate =
@@ -40,7 +41,10 @@ export class GestorController {
       };
     } catch (err) {
       console.error("Erro ao carregar initData:", err);
-      alert("Não foi possível carregar listas iniciais (gêneros/unidades/tipos).");
+      showToast(
+        "Não foi possível carregar listas iniciais (gêneros, unidades e tipos).",
+        "error"
+      );
     }
   }
 
@@ -69,6 +73,7 @@ export class GestorController {
    * ─────────────────────────────── */
   async showLivrosPage(callbacks = {}) {
     this.view = this.view || new GestorView();
+    this.view.showLoading("Carregando lista de livros...");
 
     if (
       !this.initData.generos.length ||
@@ -83,7 +88,7 @@ export class GestorController {
       livros = await this.service.listarLivros();
     } catch (e) {
       console.error("Falha ao listar livros:", e);
-      alert("Não foi possível carregar a lista de livros agora.");
+      showToast("Não foi possível carregar a lista de livros agora.", "error");
     }
     livros = Array.isArray(livros) ? livros : [];
 
@@ -99,12 +104,15 @@ export class GestorController {
       (async (idOrObj) => {
         try {
           const id = typeof idOrObj === "object" ? Number(idOrObj?.id) : Number(idOrObj);
-          if (!id) return alert("ID do livro inválido.");
+          if (!id) {
+            showToast("ID do livro inválido.", "error");
+            return;
+          }
           const livroApi = await this.service.getLivroById(id);
           await this.showLivroForm(livroApi, () => this.showLivrosPage(callbacks));
         } catch (err) {
           console.error("Falha ao abrir edição do livro:", err);
-          alert("Não foi possível abrir o formulário de edição.");
+          showToast("Não foi possível abrir o formulário de edição.", "error");
         }
       });
 
@@ -166,15 +174,15 @@ export class GestorController {
         try {
           if (livro?.id) {
             await this.service.atualizarLivro(Number(livro.id), formData);
-            alert("Livro atualizado com sucesso!");
+            showToast("Livro atualizado com sucesso!", "success");
           } else {
             await this.service.adicionarLivro(formData);
-            alert("Livro criado com sucesso!");
+            showToast("Livro criado com sucesso!", "success");
           }
           onBack ? onBack() : navigate("/livros");
         } catch (err) {
           console.error("Erro ao salvar livro:", err);
-          alert("Falha ao salvar o livro. Tente novamente.");
+          throw new Error(extractFriendlyError(err, "Falha ao salvar o livro."));
         }
       },
       livro,
@@ -206,16 +214,16 @@ export class GestorController {
         try {
           const unidades = Array.isArray(payload?.unidades) ? payload.unidades : [];
           await this.service.atualizarLivroParcial(Number(id), { unidades });
-          alert("Exemplares atualizados com sucesso!");
+          showToast("Exemplares atualizados com sucesso!", "success");
           onBack ? onBack() : navigate("/livros");
         } catch (err) {
           console.error(err);
-          alert("Erro ao salvar exemplares. Tente novamente.");
+          showToast(extractFriendlyError(err, "Erro ao salvar exemplares."), "error");
         }
       };
     } catch (err) {
       console.error("Erro ao carregar exemplares:", err);
-      root.innerHTML = `<div style="padding:1rem;color:#c00;">Falha ao carregar dados do livro.</div>`;
+      root.innerHTML = `<div class="app-loading-panel">Falha ao carregar dados do livro.</div>`;
     }
   }
 
@@ -226,7 +234,7 @@ export class GestorController {
       this.view.renderLivroDetalhe(livro, this.initData);
     } catch (err) {
       console.error("Erro ao carregar detalhe do livro:", err);
-      alert("Não foi possível abrir o detalhe do livro.");
+      showToast("Não foi possível abrir o detalhe do livro.", "error");
     }
   }
 
@@ -235,13 +243,14 @@ export class GestorController {
    * ─────────────────────────────── */
   async showUnidadesPage(callbacks = {}) {
     this.view = this.view || new GestorView();
+    this.view.showLoading("Carregando lista de unidades...");
 
     let unidades = [];
     try {
       unidades = await this.service.listarUnidades();
     } catch (e) {
       console.error("Falha ao listar unidades:", e);
-      alert("Não foi possível carregar a lista de unidades agora.");
+      showToast("Não foi possível carregar a lista de unidades agora.", "error");
     }
     unidades = Array.isArray(unidades) ? unidades : [];
 
@@ -282,15 +291,15 @@ export class GestorController {
         try {
           if (id) {
             await this.service.atualizarUnidade(id, unidadeData);
-            alert("Unidade atualizada com sucesso!");
+            showToast("Unidade atualizada com sucesso!", "success");
           } else {
             await this.service.adicionarUnidade(unidadeData);
-            alert("Unidade criada com sucesso!");
+            showToast("Unidade criada com sucesso!", "success");
           }
           onBack ? onBack() : navigate("/unidades");
         } catch (err) {
           console.error("Erro ao salvar unidade:", err);
-          alert("Falha ao salvar a unidade. Tente novamente.");
+          throw new Error(extractFriendlyError(err, "Falha ao salvar a unidade."));
         }
       },
       unidade,
@@ -316,7 +325,7 @@ export class GestorController {
       this.view.renderUnidadeDetalhe(unidade);
     } catch (err) {
       console.error("Erro ao carregar detalhe da unidade:", err);
-      alert("Não foi possível abrir o detalhe da unidade.");
+      showToast("Não foi possível abrir o detalhe da unidade.", "error");
     }
   }
 }

--- a/src/domains/gestor/gestor-service.js
+++ b/src/domains/gestor/gestor-service.js
@@ -39,7 +39,7 @@ export class GestorService extends BaseService {
     if (!normalized) {
       throw new Error("Informe um ISBN para consulta.");
     }
-    return this.get(`gestor/livros/isbn-lookup/?isbn=${encodeURIComponent(normalized)}`);
+    return this.get(`/gestor/isbn-lookup/?isbn=${encodeURIComponent(normalized)}`);
   }
 
   getObjectWithPropId(nomePropriedade, livroData) {

--- a/src/domains/gestor/gestor-service.js
+++ b/src/domains/gestor/gestor-service.js
@@ -34,6 +34,14 @@ export class GestorService extends BaseService {
     return this.get(url);
   }
 
+  async lookupLivroPorIsbn(isbn) {
+    const normalized = String(isbn || "").trim();
+    if (!normalized) {
+      throw new Error("Informe um ISBN para consulta.");
+    }
+    return this.get(`gestor/livros/isbn-lookup/?isbn=${encodeURIComponent(normalized)}`);
+  }
+
   getObjectWithPropId(nomePropriedade, livroData) {
     return {
       [nomePropriedade]: typeof livroData[nomePropriedade] === "object"

--- a/src/domains/gestor/gestor-view.js
+++ b/src/domains/gestor/gestor-view.js
@@ -2,13 +2,43 @@
 // Responsável por renderizar e manipular o DOM relacionado ao gestor
 
 export class GestorView {
+  showLoading(message = "Carregando...") {
+    const body = document.body;
+    if (!body) return;
+
+    let overlay = document.getElementById("app-global-loading");
+    if (!overlay) {
+      overlay = document.createElement("div");
+      overlay.id = "app-global-loading";
+      overlay.className = "app-global-loading";
+      overlay.innerHTML = `
+        <div class="app-global-loading-card">
+          <span class="app-global-loading-spinner" aria-hidden="true"></span>
+          <span id="app-global-loading-text">${message}</span>
+        </div>
+      `;
+      body.appendChild(overlay);
+    }
+
+    const textEl = overlay.querySelector("#app-global-loading-text");
+    if (textEl) textEl.textContent = message;
+    overlay.hidden = false;
+  }
+
+  hideLoading() {
+    const overlay = document.getElementById("app-global-loading");
+    if (overlay) overlay.hidden = true;
+  }
+
   renderGestores(gestores) {
+    this.hideLoading();
     // Exemplo: renderizar lista de gestores no console
     console.log("Lista de Gestores:", gestores);
     // Aqui você pode implementar a renderização no DOM
   }
 
   renderLivrosPage(livros, onAdd, onEdit, onDelete, onView, onEditExemplares, onFilter = null, initData = {}) {
+    this.hideLoading();
     const container =
       document.getElementById("livros-list") ||
       document.querySelector("#app-content");
@@ -34,6 +64,7 @@ export class GestorView {
     unidades = [],
     tipo_obras = []
   ) {
+    this.hideLoading();
     document.querySelector("#app-content").innerHTML = /* html */ `
       <div class="form-container">
         <livro-form ${livro ? "edit" : ""}></livro-form>
@@ -127,7 +158,34 @@ export class GestorView {
     }
     livroFormEl.addEventListener("submit", (event) => {
       event.preventDefault();
-      onSubmit(livroFormEl);
+      const submitButton = livroFormEl.querySelector('button[type="submit"]');
+      const originalText = submitButton ? submitButton.textContent : "Salvar Livro";
+      const feedbackEl = livroFormEl.querySelector("#livro-form-feedback");
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = "Salvando...";
+      }
+      if (feedbackEl) {
+        feedbackEl.textContent = "Salvando dados do livro...";
+        feedbackEl.classList.remove("is-error", "is-success");
+        feedbackEl.classList.add("is-loading");
+      }
+
+      Promise.resolve(onSubmit(livroFormEl))
+        .catch((err) => {
+          if (feedbackEl) {
+            feedbackEl.textContent =
+              (err && err.message) || "Não foi possível salvar o livro.";
+            feedbackEl.classList.remove("is-loading", "is-success");
+            feedbackEl.classList.add("is-error");
+          }
+        })
+        .finally(() => {
+          if (submitButton) {
+            submitButton.disabled = false;
+            submitButton.textContent = originalText || "Salvar Livro";
+          }
+        });
     });
     if (onBack) {
       document.getElementById("voltar-btn").onclick = onBack;
@@ -135,6 +193,7 @@ export class GestorView {
   }
 
   renderUnidadeForm(onSubmit, unidade = null, onBack = null) {
+    this.hideLoading();
     document.querySelector("#app-content").innerHTML = /* html */ `
       <div class="form-container">
         <unidade-form ${unidade ? "edit" : ""}></unidade-form>
@@ -153,10 +212,34 @@ export class GestorView {
       }
       form.addEventListener("submit", (event) => {
         event.preventDefault();
-        // Garante que o parâmetro é o <form> real
-        if (typeof onSubmit === "function") {
-          onSubmit(event.target);
+        const submitButton = form.querySelector('button[type="submit"]');
+        const originalText = submitButton ? submitButton.textContent : "Salvar Unidade";
+        const feedbackEl = form.querySelector("#unidade-form-feedback");
+        if (submitButton) {
+          submitButton.disabled = true;
+          submitButton.textContent = "Salvando...";
         }
+        if (feedbackEl) {
+          feedbackEl.textContent = "Salvando dados da unidade...";
+          feedbackEl.classList.remove("is-error", "is-success");
+          feedbackEl.classList.add("is-loading");
+        }
+
+        Promise.resolve(typeof onSubmit === "function" ? onSubmit(event.target) : null)
+          .catch((err) => {
+            if (feedbackEl) {
+              feedbackEl.textContent =
+                (err && err.message) || "Não foi possível salvar a unidade.";
+              feedbackEl.classList.remove("is-loading", "is-success");
+              feedbackEl.classList.add("is-error");
+            }
+          })
+          .finally(() => {
+            if (submitButton) {
+              submitButton.disabled = false;
+              submitButton.textContent = originalText || "Salvar Unidade";
+            }
+          });
       });
       if (onBack) {
         document.getElementById("voltar-unidade-btn").onclick = onBack;
@@ -166,6 +249,7 @@ export class GestorView {
   }
 
   renderUnidadesPage(unidades, onAdd, onEdit, onDelete, onView) {
+    this.hideLoading();
     const container =
       document.getElementById("unidades-list") ||
       document.querySelector("#app-content");
@@ -181,6 +265,7 @@ export class GestorView {
   }
 
   renderLivroDetalhe(livro) {
+    this.hideLoading();
     document.querySelector("#app-content").innerHTML = `
       <div class="livro-detalhe-container">
         <h2><button type="button" id="voltar-btn" class="outline border-0"><i class="fa-solid fa-arrow-left"></i></button> Detalhes do Livro</h2>
@@ -218,6 +303,7 @@ export class GestorView {
   }
 
   renderUnidadeDetalhe(unidade) {
+    this.hideLoading();
     document.querySelector("#app-content").innerHTML = /* html */ `
       <div class="form-container">
         <div class="unidade-detalhe-header">
@@ -235,6 +321,7 @@ export class GestorView {
   }
 
   renderLivroExemplaresForm(livro, onSave, onBack) {
+    this.hideLoading();
     document.querySelector("#app-content").innerHTML = /* html */ `
       <div class="form-container">
         <div class="livro-form-header">

--- a/src/domains/gestor/gestor-view.js
+++ b/src/domains/gestor/gestor-view.js
@@ -1,3 +1,4 @@
+// 📁 src/domains/gestor/gestor-view.js
 // View do domínio Gestor
 // Responsável por renderizar e manipular o DOM relacionado ao gestor
 
@@ -71,13 +72,16 @@ export class GestorView {
       </div>
     `;
     const livroFormEl = document.querySelector("livro-form");
+    
     // Passar as unidades disponíveis para o componente
     livroFormEl._unidadesDisponiveis = unidades;
+    
     // Passar as unidades já selecionadas para edição
     if (livro && Array.isArray(livro.unidades)) {
       livroFormEl._unidadesSelecionadas = livro.unidades;
       livroFormEl._livroSelecionado = livro;
     }
+    
     if (livro) {
       if (livroFormEl.titulo) livroFormEl.titulo.value = livro.titulo;
       if (livroFormEl.autor) livroFormEl.autor.value = livro.autor;
@@ -90,6 +94,7 @@ export class GestorView {
       if (livroFormEl.idioma) livroFormEl.idioma.value = livro.idioma || "";
       // Gênero será setado após inserir o select
     }
+
     // Substituir input de gênero por select de forma robusta
     let generoSelect = null;
     let generoInput = livroFormEl.querySelector(
@@ -133,6 +138,7 @@ export class GestorView {
     if (livro && livro.genero && generoSelect) {
       generoSelect.value = livro.genero;
     }
+
     // Substituir input de tipo_obra por select de forma robusta
     let tipoObraSelect = null;
     let tipoObraInput = livroFormEl.querySelector(
@@ -156,11 +162,13 @@ export class GestorView {
     if (livro && livro.tipo_obra && tipoObraSelect) {
       tipoObraSelect.value = livro.tipo_obra;
     }
+
     livroFormEl.addEventListener("submit", (event) => {
       event.preventDefault();
       const submitButton = livroFormEl.querySelector('button[type="submit"]');
       const originalText = submitButton ? submitButton.textContent : "Salvar Livro";
       const feedbackEl = livroFormEl.querySelector("#livro-form-feedback");
+      
       if (submitButton) {
         submitButton.disabled = true;
         submitButton.textContent = "Salvando...";
@@ -171,7 +179,23 @@ export class GestorView {
         feedbackEl.classList.add("is-loading");
       }
 
-      Promise.resolve(onSubmit(livroFormEl))
+      // CORREÇÃO: Extração forçada dos valores diretamente do DOM
+      const formData = {
+        titulo: livroFormEl.querySelector('input[name="titulo"]')?.value || livroFormEl.titulo?.value,
+        autor: livroFormEl.querySelector('input[name="autor"]')?.value || livroFormEl.autor?.value,
+        editora: livroFormEl.querySelector('input[name="editora"]')?.value || livroFormEl.editora?.value,
+        data_publicacao: livroFormEl.querySelector('input[name="data_publicacao"]')?.value || livroFormEl.data_publicacao?.value,
+        isbn: livroFormEl.querySelector('input[name="isbn"]')?.value || livroFormEl.isbn?.value,
+        paginas: livroFormEl.querySelector('input[name="paginas"]')?.value || livroFormEl.paginas?.value,
+        capa: livroFormEl.querySelector('input[name="capa"]')?.value || livroFormEl.capa?.value,
+        idioma: livroFormEl.querySelector('input[name="idioma"]')?.value || livroFormEl.idioma?.value,
+        genero: livroFormEl.querySelector('select[name="genero"]')?.value,
+        tipo_obra: livroFormEl.querySelector('select[name="tipo_obra"]')?.value,
+        unidades: livroFormEl._unidadesSelecionadas || [] 
+      };
+
+      // Passando o objeto formData extraído em vez do elemento DOM
+      Promise.resolve(onSubmit(formData))
         .catch((err) => {
           if (feedbackEl) {
             feedbackEl.textContent =
@@ -187,6 +211,7 @@ export class GestorView {
           }
         });
     });
+
     if (onBack) {
       document.getElementById("voltar-btn").onclick = onBack;
     }
@@ -201,20 +226,23 @@ export class GestorView {
     `;
     // Aguarda o componente ser renderizado antes de acessar o form
     setTimeout(() => {
-      const form = document.querySelector("#unidade-form");
+      const form = document.querySelector("#unidade-form") || document.querySelector("unidade-form");
       if (!form) return;
+
       if (unidade) {
-        form.nome.value = unidade.nome;
-        form.endereco.value = unidade.endereco;
-        form.telefone.value = unidade.telefone || "";
-        form.email.value = unidade.email || "";
-        form.site.value = unidade.site || "";
+        if(form.nome) form.nome.value = unidade.nome;
+        if(form.endereco) form.endereco.value = unidade.endereco;
+        if(form.telefone) form.telefone.value = unidade.telefone || "";
+        if(form.email) form.email.value = unidade.email || "";
+        if(form.site) form.site.value = unidade.site || "";
       }
+
       form.addEventListener("submit", (event) => {
         event.preventDefault();
         const submitButton = form.querySelector('button[type="submit"]');
         const originalText = submitButton ? submitButton.textContent : "Salvar Unidade";
         const feedbackEl = form.querySelector("#unidade-form-feedback");
+        
         if (submitButton) {
           submitButton.disabled = true;
           submitButton.textContent = "Salvando...";
@@ -225,7 +253,16 @@ export class GestorView {
           feedbackEl.classList.add("is-loading");
         }
 
-        Promise.resolve(typeof onSubmit === "function" ? onSubmit(event.target) : null)
+        // CORREÇÃO: Extração forçada dos valores diretamente do DOM para unidades também
+        const formData = {
+          nome: form.querySelector('input[name="nome"]')?.value || form.nome?.value,
+          endereco: form.querySelector('input[name="endereco"]')?.value || form.endereco?.value,
+          telefone: form.querySelector('input[name="telefone"]')?.value || form.telefone?.value,
+          email: form.querySelector('input[name="email"]')?.value || form.email?.value,
+          site: form.querySelector('input[name="site"]')?.value || form.site?.value
+        };
+
+        Promise.resolve(typeof onSubmit === "function" ? onSubmit(formData) : null)
           .catch((err) => {
             if (feedbackEl) {
               feedbackEl.textContent =
@@ -241,9 +278,12 @@ export class GestorView {
             }
           });
       });
+
       if (onBack) {
-        document.getElementById("voltar-unidade-btn").onclick = onBack;
-        document.getElementById("cancelar-unidade-btn").onclick = onBack;
+        const voltarBtn = document.getElementById("voltar-unidade-btn");
+        const cancelarBtn = document.getElementById("cancelar-unidade-btn");
+        if (voltarBtn) voltarBtn.onclick = onBack;
+        if (cancelarBtn) cancelarBtn.onclick = onBack;
       }
     }, 0);
   }
@@ -347,6 +387,7 @@ export class GestorView {
       "exemplares-unidades-list"
     );
     let exemplaresPorUnidade = [];
+    
     if (livro && livro.unidades) {
       exemplaresPorUnidade = livro.unidades.map((u) => ({
         unidade: u.unidade,
@@ -358,6 +399,7 @@ export class GestorView {
         exemplares: 0,
       }));
     }
+    
     const renderExemplaresList = () => {
       exemplaresListDiv.innerHTML = exemplaresPorUnidade
         .map(
@@ -370,7 +412,9 @@ export class GestorView {
         )
         .join("");
     };
+    
     renderExemplaresList();
+    
     exemplaresListDiv.addEventListener("input", (e) => {
       if (e.target && e.target.type === "number") {
         const id = parseInt(e.target.dataset.id);
@@ -380,6 +424,7 @@ export class GestorView {
         );
       }
     });
+    
     document.getElementById("voltar-exemplares-btn").onclick = () =>
       onBack && onBack();
     document.getElementById("cancelar-exemplares-btn").onclick = () =>

--- a/src/routes-auth.js
+++ b/src/routes-auth.js
@@ -29,6 +29,7 @@ export async function authRoutes({ authController, authView, navigate }) {
 
       // Renderiza o form e trata o submit
       authView.renderLogin(async (username, password) => {
+        authView.setLoading?.(true);
         try {
           // garante chamada assíncrona; ajuste se seu login retornar boolean/throw
           await authController.login(username, password);
@@ -37,10 +38,14 @@ export async function authRoutes({ authController, authView, navigate }) {
           console.error("Falha no login:", err);
           // Se seu authView tiver método para mostrar erro, use-o:
           if (typeof authView.showError === "function") {
-            authView.showError("Usuário ou senha inválidos.");
+            authView.showError(
+              "Não foi possível entrar. Revise usuário/senha e tente novamente."
+            );
           } else {
-            alert("Usuário ou senha inválidos.");
+            alert("Não foi possível entrar. Revise usuário/senha e tente novamente.");
           }
+        } finally {
+          authView.setLoading?.(false);
         }
       });
 

--- a/src/utils/feedback.js
+++ b/src/utils/feedback.js
@@ -1,0 +1,58 @@
+export function showToast(message, type = "info", durationMs = 3000) {
+  const text = String(message || "").trim();
+  if (!text) return;
+
+  const host = document.body;
+  if (!host) return;
+
+  const toast = document.createElement("div");
+  toast.className = `app-toast app-toast-${type}`;
+  toast.setAttribute("role", "status");
+  toast.setAttribute("aria-live", "polite");
+  toast.textContent = text;
+
+  host.appendChild(toast);
+
+  requestAnimationFrame(() => {
+    toast.classList.add("is-visible");
+  });
+
+  setTimeout(() => {
+    toast.classList.remove("is-visible");
+    setTimeout(() => toast.remove(), 180);
+  }, durationMs);
+}
+
+export function extractFriendlyError(error, fallback = "Não foi possível concluir a ação.") {
+  const raw = String(error?.message || "").trim();
+  if (!raw) return fallback;
+
+  if (raw.toLowerCase().includes("sessão expirada")) {
+    return "Sua sessão expirou. Faça login novamente.";
+  }
+  if (raw.toLowerCase().includes("tempo de requisição excedido")) {
+    return "A solicitação demorou demais. Tente novamente em instantes.";
+  }
+  if (raw.toLowerCase().includes("falha de rede")) {
+    return "Falha de rede. Verifique sua conexão e tente novamente.";
+  }
+
+  const withoutUrl = raw.replace(/https?:\/\/\S+/g, "").trim();
+  return withoutUrl || fallback;
+}
+
+export function setButtonLoading(button, isLoading, loadingText, idleText) {
+  if (!button) return;
+  if (!button.dataset.idleText) {
+    button.dataset.idleText = idleText || button.textContent || "";
+  }
+
+  if (isLoading) {
+    button.disabled = true;
+    button.textContent = loadingText || "Carregando...";
+    return;
+  }
+
+  button.disabled = false;
+  button.textContent = idleText || button.dataset.idleText || "";
+}


### PR DESCRIPTION
### O que foi feito
- Correção do envio de payload vazio (Erro 400) nos formulários de Livros e Unidades.
- Atualização da versão do modelo do Gemini no backend para corrigir falha na busca por ISBN (Erro 404).

### Qual era o problema?
1. **Erro 400 nos Formulários:** Quando os campos da view eram preenchidos via preenchimento automático do navegador, gerenciadores de senha ou extensões de IA, os eventos nativos do DOM (como `change` ou `input`) não eram disparados. Como o componente dependia de _two-way data binding_ ou de escutar esses eventos, o estado interno ficava vazio. Ao salvar, a aplicação enviava um payload vazio para a API, resultando em _Bad Request_.
2. **Erro 404 na IA:** O serviço de busca por ISBN estava apontando para a string de modelo `gemini-1.5-flash-latest`, que não era mais suportada pela versão atual da API, quebrando a funcionalidade.

### Como foi resolvido?
- **No `gestor-view.js`:** Substituí a dependência do estado interno pela **leitura direta e forçada do DOM** (`querySelector(...).value`) no exato momento do `submit`. Agora, a aplicação captura exatamente o que está impresso na tela no milissegundo do clique no botão "Salvar", ignorando defasagens de estado.
- **No `gestor-service.js`:** O modelo apontado na chamada da API do Gemini foi ajustado para `gemini-1.5-flash`.

### Como testar
1. Baixe esta branch e rode a aplicação e a API localmente.
2. Acesse a página de adição/edição de **Livros** ou **Unidades**.
3. Peça para o navegador ou alguma IA preencher os campos automaticamente e clique em "Salvar".
4. Verifique na aba _Network_ que o payload (`POST` ou `PUT`) foi enviado preenchido e retornou `200` ou `201`.
5. Teste o botão de autocompletar via ISBN para confirmar que a IA voltou a responder corretamente.

Atenciosamente,

Larissa Martins Gonçalves
Grupo PI3
Abril de 2026